### PR TITLE
Remove support for env vars other than RABBITMQ_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@ A daemon to run AMQP consumers
 
 ## Running
 
-    RABBITMQ_HOST=rabbitmq.example.com amqp-dispatcher --config amqp-dispatcher-config.yml
+    amqp-dispatcher --config amqp-dispatcher-config.yml
 
-The environment variable `RABBITMQ\_HOSTS` can also be used which will cause
-attempt to connect to a host in a random order. The list should be comma separated.
-
-    RABBITMQ_HOSTS=rabbitmq1.example.com,rabbitmq2.example.com
+The environment variable `RABBITMQ\_URL` can also be used which will cause
+attempt to connect to the defined data source name. Hosts are separated via commas, and they are connected to in random order.
 
 ## Consumers
 
@@ -64,12 +62,7 @@ YAML file for worker configuration.
 
 ### Environment Variables
 
-- `RABBITMQ_URL`: Connection string of the form `amqp://USER:PASS@HOST:PORT/VHOST`, `RABBITMQ_URL` is present, all other environment variables are ignored
-- `RABBITMQ_HOSTS` - Comma separated list of hosts to connect to
-- `RABBITMQ_HOST`  - Host to connect to
-- `RABBITMQ_USER`  - Username to connect with (default is `guest`)
-- `RABBITMQ_PASS`  - Password to connect with (default is `guest`)
-- `RABBITMQ_VHOST` - Virtual host to use (default is `/`)
+- `RABBITMQ_URL`: Connection string of the form `amqp://USER:PASS@HOST:PORT/VHOST`
 
 ### Startup Configuration
 

--- a/amqpdispatcher/dispatcher.py
+++ b/amqpdispatcher/dispatcher.py
@@ -114,44 +114,22 @@ def create_and_bind_queues(connection, queues):
         bind_queue(connection, queue)
 
 
-def get_connection_params_from_environment():
+def parse_url():
     """returns tuple containing
     HOSTS, USER, PASSWORD, VHOST
     """
-    connection_string = os.getenv('RABBITMQ_URL', None)
+    rabbitmq_url = os.getenv('RABBITMQ_URL', 'amqp://guest:guest@localhost/')
     hosts = user = password = vhost = None
 
-    # connection string, all contained
-    if connection_string:
-        cp = urlparse.urlparse(connection_string)
-        hosts_string = cp.hostname
-        hosts = hosts_string.split(",")
-        if cp.port:
-            hosts = [h + ":" + str(cp.port) for h in hosts]
-        user = cp.username
-        password = cp.password
-        vhost = cp.path
-        return (hosts, user, password, vhost)
-
-    # find hosts
-    hosts_string = os.getenv('RABBITMQ_HOSTS', None)
-    if hosts_string:
-        hosts = hosts_string.split(",")
-
-    host = os.getenv('RABBITMQ_HOST', None)
-    if host:
-        hosts = host.split(",")
-        if len(hosts) > 1:
-            raise Exception("invalid rabbitmq connection info: RABBITMQ_HOST requests a single host, received {}".format(host))
-
-    if hosts is None:
-        raise Exception("missing rabbitmq connection info: RABBITMQ_URL, RABBITMQ_HOSTS, or RABBITMQ_HOST is required")
-
-    # find other parameters from env variables
-    user = os.getenv('RABBITMQ_USER', 'guest')
-    password = os.getenv('RABBITMQ_PASS', 'guest')
-    vhost = os.getenv('RABBITMQ_VHOST', '/')
-    return hosts, user, password, vhost
+    cp = urlparse.urlparse(rabbitmq_url)
+    hosts_string = cp.hostname
+    hosts = hosts_string.split(",")
+    if cp.port:
+        hosts = [h + ":" + str(cp.port) for h in hosts]
+    user = cp.username
+    password = cp.password
+    vhost = cp.path
+    return (hosts, user, password, vhost)
 
 
 def setup():
@@ -164,7 +142,7 @@ def setup():
         startup_handler()
         logger.info('Startup handled')
 
-    hosts, user, password, vhost = get_connection_params_from_environment()
+    hosts, user, password, vhost = parse_url()
     rabbit_logger = logging.getLogger('amqp-dispatcher.haigha')
     conn = connect_to_hosts(
         RabbitConnection,

--- a/amqpdispatcher/dispatcher.py
+++ b/amqpdispatcher/dispatcher.py
@@ -120,16 +120,17 @@ def parse_url():
     """
     rabbitmq_url = os.getenv('RABBITMQ_URL', 'amqp://guest:guest@localhost/')
     hosts = user = password = vhost = None
+    port = 5672
 
     cp = urlparse.urlparse(rabbitmq_url)
     hosts_string = cp.hostname
     hosts = hosts_string.split(",")
     if cp.port:
-        hosts = [h + ":" + str(cp.port) for h in hosts]
+        port = int(cp.port)
     user = cp.username
     password = cp.password
     vhost = cp.path
-    return (hosts, user, password, vhost)
+    return (hosts, user, password, vhost, port)
 
 
 def setup():
@@ -142,11 +143,12 @@ def setup():
         startup_handler()
         logger.info('Startup handled')
 
-    hosts, user, password, vhost = parse_url()
+    hosts, user, password, vhost, port = parse_url()
     rabbit_logger = logging.getLogger('amqp-dispatcher.haigha')
     conn = connect_to_hosts(
         RabbitConnection,
         hosts,
+        port=port,
         transport='gevent',
         user=user,
         password=password,

--- a/tests/unit/test_connecting.py
+++ b/tests/unit/test_connecting.py
@@ -47,27 +47,29 @@ class TestConnectionParams(TestCase):
         rabbitmq_url = "amqp://guest:guest@test.foo.com/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = parse_url()
+            hosts, user, password, vhost, port = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
             self.assertEqual(hosts, ["test.foo.com"])
+            self.assertEqual(port, 5672)
 
     def test_connection_string_url_single_host_with_port(self):
         rabbitmq_url = "amqp://guest:guest@test.foo.com:5672/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = parse_url()
+            hosts, user, password, vhost, port = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
-            self.assertEqual(hosts, ["test.foo.com:5672"])
+            self.assertEqual(hosts, ["test.foo.com"])
+            self.assertEqual(port, 5672)
 
     def test_connection_string_url_multiple_host(self):
         rabbitmq_url = "amqp://guest:guest@server1.foo.com,server2.foo.com/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = parse_url()
+            hosts, user, password, vhost, port = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
@@ -75,16 +77,18 @@ class TestConnectionParams(TestCase):
                 "server1.foo.com",
                 "server2.foo.com"
             ])
+            self.assertEqual(port, 5672)
 
     def test_connection_string_url_multiple_host_with_port(self):
         rabbitmq_url = "amqp://guest:guest@server1.foo.com,server2.foo.com:5672/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = parse_url()
+            hosts, user, password, vhost, port = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
             self.assertEqual(sorted(hosts), [
-                "server1.foo.com:5672",
-                "server2.foo.com:5672"
+                "server1.foo.com",
+                "server2.foo.com"
             ])
+            self.assertEqual(port, 5672)

--- a/tests/unit/test_connecting.py
+++ b/tests/unit/test_connecting.py
@@ -7,7 +7,7 @@ import os
 
 from amqpdispatcher.dispatcher import connect_to_hosts
 from amqpdispatcher.dispatcher import RabbitConnection
-from amqpdispatcher.dispatcher import get_connection_params_from_environment
+from amqpdispatcher.dispatcher import parse_url
 
 
 class TestConnectingToHosts(TestCase):
@@ -47,7 +47,7 @@ class TestConnectionParams(TestCase):
         rabbitmq_url = "amqp://guest:guest@test.foo.com/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
+            hosts, user, password, vhost = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
@@ -57,7 +57,7 @@ class TestConnectionParams(TestCase):
         rabbitmq_url = "amqp://guest:guest@test.foo.com:5672/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
+            hosts, user, password, vhost = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
@@ -67,7 +67,7 @@ class TestConnectionParams(TestCase):
         rabbitmq_url = "amqp://guest:guest@server1.foo.com,server2.foo.com/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
+            hosts, user, password, vhost = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
@@ -80,7 +80,7 @@ class TestConnectionParams(TestCase):
         rabbitmq_url = "amqp://guest:guest@server1.foo.com,server2.foo.com:5672/"
         f = env_mocker({"RABBITMQ_URL": rabbitmq_url})
         with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
+            hosts, user, password, vhost = parse_url()
             self.assertEqual(user, "guest")
             self.assertEqual(password, "guest")
             self.assertEqual(vhost, "/")
@@ -88,65 +88,3 @@ class TestConnectionParams(TestCase):
                 "server1.foo.com:5672",
                 "server2.foo.com:5672"
             ])
-
-    def test_connection_string_url_bad_param(self):
-        rabbitmq_url = "amqp://guest:guest@server1.foo.com,server2.foo.com/"
-        f = env_mocker({"RABBITMQ_URL2": rabbitmq_url})
-        with patch.object(os, 'getenv', new=f):
-            self.assertRaises(Exception, get_connection_params_from_environment)
-
-    def test_connection_string_split_params(self):
-        f = env_mocker({
-            "RABBITMQ_HOSTS": "server1.foo.com,server2.foo.com",
-            "RABBITMQ_USER": "guest",
-            "RABBITMQ_PASS": "guest",
-            "RABBITMQ_VHOST": "/",
-        })
-        with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
-            self.assertEqual(user, "guest")
-            self.assertEqual(password, "guest")
-            self.assertEqual(vhost, "/")
-            self.assertEqual(sorted(hosts), [
-                "server1.foo.com",
-                "server2.foo.com"
-            ])
-
-    def test_connection_string_split_params_host(self):
-        f = env_mocker({
-            "RABBITMQ_HOST": "server1.foo.com",
-            "RABBITMQ_USER": "guest",
-            "RABBITMQ_PASS": "guest",
-            "RABBITMQ_VHOST": "/",
-        })
-        with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
-            self.assertEqual(user, "guest")
-            self.assertEqual(password, "guest")
-            self.assertEqual(vhost, "/")
-            self.assertEqual(sorted(hosts), ["server1.foo.com"])
-
-    def test_connection_string_split_params_host_port(self):
-        f = env_mocker({
-            "RABBITMQ_HOST": "server1.foo.com:15672",
-            "RABBITMQ_USER": "guest",
-            "RABBITMQ_PASS": "guest",
-            "RABBITMQ_VHOST": "/",
-        })
-        with patch.object(os, 'getenv', new=f):
-            hosts, user, password, vhost = get_connection_params_from_environment()
-            self.assertEqual(user, "guest")
-            self.assertEqual(password, "guest")
-            self.assertEqual(vhost, "/")
-            self.assertEqual(sorted(hosts), ["server1.foo.com:15672"])
-
-    def test_connection_string_split_params_host_invalid_comma(self):
-        f = env_mocker({
-            "RABBITMQ_HOST": "server1.foo.com,server2.foo.com",
-            "RABBITMQ_USER": "guest",
-            "RABBITMQ_PASS": "guest",
-            "RABBITMQ_VHOST": "/",
-        })
-
-        with patch.object(os, 'getenv', new=f):
-            self.assertRaises(Exception, get_connection_params_from_environment)


### PR DESCRIPTION
This commit removes the extra parsing, in an attempt to simplify the codebase. The env var RABBITMQ_URL is sufficient to provide all the configuration necessary for amp-dispatcher.
