### PR TITLE
Add separate steps in for copying requirements.txt and running pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 
 WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
 COPY . .
 
-RUN pip install -r requirements.txt
 
 
 ENTRYPOINT ["dockerize", "-wait", "tcp://rabbit:5672", "-timeout", "15s", "python", "-m", "amqpdispatcher.dispatcher", "--config", "./examples/amqp-dispatcher-config.yml"]


### PR DESCRIPTION
This will give better cache utilization, since code changes will not cause `pip` to install the requirements again.

See https://www.aptible.com/documentation/deploy/tutorials/faq/dockerfile-caching/pip-dockerfile-caching.html